### PR TITLE
add bottom margin

### DIFF
--- a/android/src/main/java/com/devutex/admobadvanced/AdMobAdvanced.java
+++ b/android/src/main/java/com/devutex/admobadvanced/AdMobAdvanced.java
@@ -395,12 +395,22 @@ public class AdMobAdvanced extends Plugin {
                         @Override
                         public void onAdLoaded() {
                             notifyListeners("onBannerAdLoaded", new JSObject().put("value", true));
+                            JSObject ret = new JSObject();
+                            ret.put("width", adView.getAdSize().getWidth());
+                            ret.put("height", adView.getAdSize().getHeight());
+                            notifyListeners("onAdSize", ret);
                             super.onAdLoaded();
                         }
 
                         @Override
                         public void onAdFailedToLoad(int i) {
                             notifyListeners("onBannerAdFailedToLoad", new JSObject().put("errorCode", i));
+                            
+                            JSObject ret = new JSObject();
+                            ret.put("width", 0);
+                            ret.put("height", 0);
+                            notifyListeners("onAdSize", ret);
+                            
                             super.onAdFailedToLoad(i);
                         }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -79,7 +79,9 @@ export interface AdMobAdvancedPlugin {
     // Close RewardedVideo
     stopRewarded(): Promise<{ value: boolean }>;
 
-
+    // AdMob Banner Adsize listeners
+    addListener(eventName: 'onAdSize', listenerFunc: (info: any) => void): PluginListenerHandle;
+    
     // AdMob Banner listeners
     addListener(eventName: 'onBannerAdLoaded', listenerFunc: (info: any) => void): PluginListenerHandle;
     addListener(eventName: 'onBannerAdFailedToLoad', listenerFunc: (info: any) => void): PluginListenerHandle;


### PR DESCRIPTION
When you display a footer banner, this comes to hide 50 or 100 pixel from the bottom
It would be nice to have to get this information when a banner is displayed to add margin on the htmlelement begind "ion-router-outlet"